### PR TITLE
Add support for cache counters in emotional records

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ picture.happy_emotions_count
 # Quick lookup into the column and returns `1`
 ```
 
+Same thing for emotional records. If there’s a `happy_emotions_count` column in the `User` model, Emotions will update it each time a record expresses a happy emotion towards another record.
+
+```ruby
+user.happy_about!(picture)
+
+user.happy_about.count
+# SQL query that counts records and returns `1`
+
+user.happy_emotions_count
+# Quick lookup into the column and returns `1`
+```
+
 ## License
 
 `Emotions` is © 2013 [Mirego](http://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause).  See the [`LICENSE.md`](https://github.com/mirego/emotions/blob/master/LICENSE.md) file.

--- a/lib/emotions/emotion.rb
+++ b/lib/emotions/emotion.rb
@@ -24,6 +24,7 @@ module Emotions
     # Update the `<emotion>_emotions_counter` for the emotive record
     def update_emotion_counter
       self.emotive.update_emotion_counter(self.emotion)
+      self.emotional.update_emotion_counter(self.emotion)
     end
 
     # Make sure we're using an allowed emotion name

--- a/lib/emotions/emotional.rb
+++ b/lib/emotions/emotional.rb
@@ -54,6 +54,15 @@ module Emotions
       _emotions_about(emotive).where(emotion: emotion).first.tap { |e| e.try(:destroy) }
     end
 
+    # @private
+    def update_emotion_counter(emotion)
+      attribute = "#{emotion}_emotions_count"
+
+      if self.respond_to?(attribute)
+        self.update_attribute(attribute, send("#{emotion}_about").count)
+      end
+    end
+
     module ClassMethods
       # Return an `ActiveRecord::Relation` containing the emotional records
       # that expressed a specific emotion towards an emotive record
@@ -88,8 +97,9 @@ module Emotions
             no_longer_express! #{emotion.inspect}, emotive
           end
 
-          def #{emotion}_about(emotive)
-            _emotions_about(emotive).where(emotion: #{emotion.to_s.inspect})
+          def #{emotion}_about(emotive = nil)
+            relation = emotive.nil? ? self.emotions : _emotions_about(emotive)
+            relation.where(emotion: #{emotion.to_s.inspect})
           end
 
           alias #{emotion}? #{emotion}_about?

--- a/spec/emotions/emotion_spec.rb
+++ b/spec/emotions/emotion_spec.rb
@@ -61,10 +61,12 @@ describe Emotions::Emotion do
   describe :Callbacks do
     describe :update_emotion_counter_on_create do
       let(:picture) { Picture.create }
-      let(:emotion) { described_class.new(emotion: 'happy', emotional: User.create, emotive: picture) }
+      let(:user) { User.create }
+      let(:emotion) { described_class.new(emotion: 'happy', emotional: user, emotive: picture) }
 
       before do
         picture.should_receive(:update_emotion_counter).with('happy').once
+        user.should_receive(:update_emotion_counter).with('happy').once
         emotion.should_receive(:update_emotion_counter).once.and_call_original
       end
 
@@ -73,11 +75,13 @@ describe Emotions::Emotion do
 
     describe :update_emotion_counter_on_destroy do
       let(:picture) { Picture.create }
-      let(:emotion) { described_class.new(emotion: 'happy', emotional: User.create, emotive: picture) }
+      let(:user) { User.create }
+      let(:emotion) { described_class.new(emotion: 'happy', emotional: user, emotive: picture) }
 
       before do
         emotion.save!
         picture.should_receive(:update_emotion_counter).with('happy').once
+        user.should_receive(:update_emotion_counter).with('happy').once
         emotion.should_receive(:update_emotion_counter).once.and_call_original
       end
 

--- a/spec/emotions/emotional_spec.rb
+++ b/spec/emotions/emotional_spec.rb
@@ -5,7 +5,10 @@ describe Emotions::Emotional do
     emotions :happy, :sad
 
     run_migration do
-      create_table(:users, force: true)
+      create_table(:users, force: true) do |t|
+        t.integer :happy_emotions_count, default: 0
+        t.integer :sad_emotions_count, default: 0
+      end
       create_table(:pictures, force: true)
     end
 
@@ -139,6 +142,20 @@ describe Emotions::Emotional do
           it { expect(user.no_longer_happy_about! user).to be_nil }
           it { expect{ user.no_longer_happy_about! user }.to_not raise_error }
         end
+      end
+
+      describe :update_emotion_counter do
+        let(:user) { User.create }
+        let(:relation) do
+          double.tap { |double| double.stub(:count).and_return(42) }
+        end
+
+        before do
+          User.any_instance.stub(:happy_about).and_return(relation)
+          user.update_emotion_counter(:happy)
+        end
+
+        it { expect(user.reload.happy_emotions_count).to eql 42 }
       end
     end
   end


### PR DESCRIPTION
We had this feature for emotive records. Thought it would be cool to have it for emotional records as well.
