### PR TITLE
Add express? method to emotional

### DIFF
--- a/lib/emotions/emotional.rb
+++ b/lib/emotions/emotional.rb
@@ -63,6 +63,16 @@ module Emotions
       end
     end
 
+    # Find if an emotion is expressed towards another record
+    #
+    # @example
+    #   user = User.first
+    #   picture = Picture.first
+    #   user.express? :happy, picture
+    def express?(emotion, emotive)
+      _emotions_about(emotive).where(emotion: emotion).any?
+    end
+
     module ClassMethods
       # Return an `ActiveRecord::Relation` containing the emotional records
       # that expressed a specific emotion towards an emotive record

--- a/spec/emotions/emotional_spec.rb
+++ b/spec/emotions/emotional_spec.rb
@@ -98,6 +98,20 @@ describe Emotions::Emotional do
       end
     end
 
+    describe :express? do
+      let(:picture) { Picture.create }
+
+      context 'when expressed' do
+        before { user.happy_about!(picture) }
+
+        it { expect(user.express? :happy, picture).to be_truthy }
+      end
+
+      context 'when not expressed' do
+        it { expect(user.express? :happy, picture).to be_falsey }
+      end
+    end
+
     describe :DynamicMethods do
       describe :emotion_about? do
         before { user.happy_about!(picture) }


### PR DESCRIPTION
In some case, the emotion is not very usable with our alias. Take `archive` for example:

```ruby
# Bad
archive_about!(email)
no_longer_archive_about!(email)
archive_about?(email)

# Good
express!(:archive, email)
no_longer_express!(:archive, email)
express?(:archive, email)
```

This pull request introduce the `express?` method.