### PR TITLE
Fix deprecation warning with timestamp in migrations

### DIFF
--- a/lib/generators/emotions/templates/migration.rb
+++ b/lib/generators/emotions/templates/migration.rb
@@ -10,7 +10,7 @@ class AddEmotions < ActiveRecord::Migration
       # The type of emotion
       t.string :emotion
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :emotions, [:emotional_type, :emotional_id, :emotive_type, :emotive_id, :emotion], unique: true, name: 'index_emotions_by_emotional_emotive_and_emotion'


### PR DESCRIPTION
As you can see in the [Travis log](https://travis-ci.org/mirego/emotions/jobs/63706157), we had a deprecation warning for Rails 5:

```
DEPRECATION WARNING: `#timestamp` was called without specifying an option for `null`. In Rails 5, this behavior will change to
 `null: false`. You should manually specify `null: true` to prevent the behavior of your existing migrations from changing. (ca
lled from block in up at /Volumes/Mirego/Code/emotions/lib/generators/emotions/templates/migration.rb:13)